### PR TITLE
Allow for optional list of bufnames to not resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * Calculates the minimum width (80 by default) + line numbers/signs/etc
 * Won't shrink the current window
 * Won't resize side panels (supports NERDTree and vimpanel)
+  * Additional bufname entries can be specified as an array. See [Configuration & Defaults](#configuration--defaults)
 
 ## Installation
 
@@ -42,4 +43,5 @@ let g:eighties_enabled = 1
 let g:eighties_minimum_width = 80
 let g:eighties_extra_width = 0 " Increase this if you want some extra room
 let g:eighties_compute = 1 " Disable this if you just want the minimum + extra
+let g:eighties_bufname_additional_patterns = ['fugitiveblame'] " Defaults to [], 'fugitiveblame' is only an example. Takes a comma delimited list of bufnames as strings.
 ```

--- a/autoload/eighties.vim
+++ b/autoload/eighties.vim
@@ -29,7 +29,12 @@ function! s:in_file_browser()
     return 1
   endif
 
-  for pattern in ["NERD_tree", "vimpanel"]
+  let patterns = ["NERD_tree", "vimpanel"]
+  if exists('g:eighties_bufname_additional_patterns')
+    let patterns = patterns + g:eighties_bufname_additional_patterns
+  endif
+
+  for pattern in patterns
     if bufname("%") =~ pattern
       return 1
     endif


### PR DESCRIPTION
usage:

```viml
let g:eighties_bufname_additional_patterns = ['fugitiveblame']
```

This way if you do a `:Gblame` on a file, then navigate around with the
blame open, it won't get re-sized. It's the same behavior we want from
NERDTree too, but instead of just hard-coding it in that array I made it
configurable.